### PR TITLE
Report code coverage using Codecov

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "Run tests" {
   on = "push"
-  resolves = ["Unit tests", "Check codestyle", "Static code analysis"]
+  resolves = ["Unit tests", "Check codestyle", "Static code analysis", "Send coverage to Codecov"]
 }
 
 action "Composer install" {
@@ -24,4 +24,10 @@ action "Static code analysis" {
   needs = ["Composer install"]
   uses = "docker://php:7.2-alpine"
   runs = "vendor/bin/phpstan analyse"
+}
+
+action "Send coverage to Codecov" {
+  needs = ["Unit tests"]
+  uses = "Atrox/codecov-action@v0.1.3"
+  secrets = ["CODECOV_TOKEN"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 .phpunit.result.cache
 .env
+clover.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Adgangsplatformen Provider for OAuth 2.0 Client
 
+[![codecov](https://codecov.io/gh/reload/oauth2-adgangsplatformen/branch/master/graph/badge.svg)](https://codecov.io/gh/reload/oauth2-adgangsplatformen)
+
 This package provides OAuth 2.0 for accessing [Adgangsplatformen](https://github.com/DBCDK/hejmdal) currently running at https://login.bib.dk/ - a single sign-on solution for public libraries in Denmark. It is based on the PHP League's [OAuth 2.0 Client](https://github.com/thephpleague/oauth2-client).
 
 ## Usage

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-clover" target="/tmp/coverage.xml"/>
+        <log type="coverage-clover" target="clover.xml"/>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
Use [an existing action](https://github.com/marketplace/actions/codecov-action) to achieve this.

Update PHPUnit configuration to output the coverage file to the
current directory as that locations seems to be required by the 
action.

Ignore the coverage file from VCS.