### PR TITLE
Update revoke endpoint

### DIFF
--- a/src/Provider/Adgangsplatformen.php
+++ b/src/Provider/Adgangsplatformen.php
@@ -127,7 +127,7 @@ class Adgangsplatformen extends AbstractProvider
     public function revokeAccessToken(AccessTokenInterface $token): void
     {
         $url = $this->appendQuery(
-            'https://login.bib.dk/revoke/',
+            'https://login.bib.dk/oauth/revoke',
             $this->buildQueryString(['access_token' => $token->getToken()])
         );
         $request = $this->createRequest('DELETE', $url, $token, []);


### PR DESCRIPTION
According to Adgangdplatformen developers the correct endpoint for revoking tokens is not what is says in the documentation.

Update this accordingly.