### PR TITLE
Simplify GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,56 +3,49 @@ name: Build and test
 jobs:
   check_codestyle:
     name: Codestyle
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Check codestyle
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: vendor/bin/phpcs
   static_code_analysis:
     name: Static Code Analysis
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Static code analysis
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: vendor/bin/phpstan
         args: analyse
   unit_tests:
     name: Unit tests
+    if: '!github.event.deleted'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      if: '!github.event.deleted'
     - name: Composer install
-      if: '!github.event.deleted'
       uses: MilesChou/composer-action@master
       with:
         args: install
     - name: Unit tests
-      if: '!github.event.deleted'
       uses: docker://php:7.3-alpine
       with:
         entrypoint: phpdbg
         args: -qrr vendor/bin/phpunit
     - name: Unit Codecov
-      if: '!github.event.deleted'
       uses: Atrox/codecov-action@v0.1.3
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Simplify GitHub Actions by moving if conditions from each step and into the job instead.

[This is now supported](https://github.community/t5/GitHub-API-Development-and/jobs-lt-job-id-gt-if-not-working/m-p/32721#M3094).