### PR TITLE
Drop obsolete fork of PSR15-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,12 +2,6 @@
     "name": "danskernesdigitalebibliotek/oauth2-adgangsplatformen",
     "description": "OAuth 2.0 provider for using Adgangsplatformen - a single sign-on solution for public libraries in Denmark",
     "type": "library",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/reload/laravel-psr15-bridge"
-        }
-    ],
     "require": {
         "php": "^7.2",
         "ext-json": "*",
@@ -46,7 +40,7 @@
         "phpunit/phpunit": "^8.2",
         "psr/http-server-middleware": "^1.0",
         "rtheunissen/guzzle-log-middleware": "^0.4.2",
-        "softonic/laravel-psr15-bridge": "dev-laravel-6",
+        "softonic/laravel-psr15-bridge": "^1.1",
         "squizlabs/php_codesniffer": "^3.4",
         "vlucas/phpdotenv": "^3.4"
     }

--- a/tests/Support/PSR15/TokenResourceOwnerValidatorTest.php
+++ b/tests/Support/PSR15/TokenResourceOwnerValidatorTest.php
@@ -31,11 +31,12 @@ class TokenResourceOwnerValidatorTest extends TestCase
 
         $handler = $this->createMock(RequestHandlerInterface::class);
         $handler->method('handle')
-            ->with($this->callback(function (ServerRequestInterface $request
-            ) use ($resourceOwner, $attributeName) {
-                $this->assertEquals($resourceOwner, $request->getAttribute($attributeName));
-                return true;
-            }));
+            ->with($this->callback(
+                function (ServerRequestInterface $request) use ($resourceOwner, $attributeName) {
+                    $this->assertEquals($resourceOwner, $request->getAttribute($attributeName));
+                    return true;
+                }
+            ));
 
         $middleware->process($request, $handler);
     }


### PR DESCRIPTION
This is no longer needed as our PR has been merged upstream and
included from release 1.1.0.